### PR TITLE
Feature/refactor parse

### DIFF
--- a/src/code_m68k.rs
+++ b/src/code_m68k.rs
@@ -20,7 +20,7 @@ impl Default for ObjSimpleHunk {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Copy)]
 pub enum ObjCodeFlag {
     None,
     GlobalMultiDef,
@@ -50,7 +50,7 @@ impl Default for ObjCodeHunk {
 }
 
 impl ObjCodeHunk {
-    pub fn new(
+    fn new(
         name_id: u32,
         sym_offset: u32,
         sym_decl_offset: u32,
@@ -73,6 +73,14 @@ impl ObjCodeHunk {
     pub fn code_iter(&self) -> Iter<u8> {
         self.code.iter()
     }
+
+    pub fn sym_decl_offset(&self) -> u32 {
+        self.sym_decl_offset
+    }
+
+    pub fn flag(&self) -> ObjCodeFlag {
+        self.special_flag
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -81,10 +89,18 @@ pub struct ObjInitHunk {
 }
 
 impl ObjInitHunk {
-    pub fn new(code: &[u8]) -> Self {
+    fn new(code: &[u8]) -> Self {
         Self {
             code: code.to_owned(),
         }
+    }
+
+    pub fn code_iter(&self) -> Iter<u8> {
+        self.code.iter()
+    }
+
+    pub fn code(&self) -> &[u8] {
+        &self.code
     }
 }
 
@@ -97,7 +113,7 @@ pub struct ObjDataHunk {
 }
 
 impl ObjDataHunk {
-    pub fn new(name_id: u32, sym_type_id: u32, sym_decl_offset: u32, code: &[u8]) -> Self {
+    fn new(name_id: u32, sym_type_id: u32, sym_decl_offset: u32, code: &[u8]) -> Self {
         Self {
             name_id: name_id,
             sym_type_id: sym_type_id,
@@ -109,6 +125,14 @@ impl ObjDataHunk {
     pub fn data_iter(&self) -> Iter<u8> {
         self.data.iter()
     }
+
+    pub fn sym_type_id(&self) -> u32 {
+        self.sym_type_id
+    }
+
+    pub fn sym_decl_offset(&self) -> u32 {
+        self.sym_decl_offset
+    }
 }
 
 #[derive(NameIdFromObject, Debug, Clone)]
@@ -118,11 +142,15 @@ pub struct ObjEntryHunk {
 }
 
 impl ObjEntryHunk {
-    pub fn new(name_id: u32, offset: u32) -> Self {
+    fn new(name_id: u32, offset: u32) -> Self {
         Self {
             name_id: name_id,
             offset: offset,
         }
+    }
+
+    pub fn offset(&self) -> u32 {
+        self.offset
     }
 }
 
@@ -133,11 +161,19 @@ pub struct ObjXRefPair {
 }
 
 impl ObjXRefPair {
-    pub fn new(offset: u32, value: u32) -> Self {
+    fn new(offset: u32, value: u32) -> Self {
         Self {
             offset: offset,
             value: value,
         }
+    }
+
+    pub fn offset(&self) -> u32 {
+        self.offset
+    }
+
+    pub fn value(&self) -> u32 {
+        self.value
     }
 }
 
@@ -148,7 +184,7 @@ pub struct ObjXRefHunk {
 }
 
 impl ObjXRefHunk {
-    pub fn new(name_id: u32, pairs: Vec<ObjXRefPair>) -> Self {
+    fn new(name_id: u32, pairs: Vec<ObjXRefPair>) -> Self {
         Self {
             name_id: name_id,
             pairs: pairs,
@@ -166,10 +202,18 @@ pub struct ObjExceptInfo {
 }
 
 impl ObjExceptInfo {
-    pub fn new(info: &[u8]) -> Self {
+    fn new(info: &[u8]) -> Self {
         Self {
             info: info.to_vec(),
         }
+    }
+
+    pub fn info(&self) -> &[u8] {
+        &self.info
+    }
+
+    pub fn info_iter(&self) -> Iter<u8> {
+        self.info.iter()
     }
 }
 
@@ -182,18 +226,25 @@ pub struct ObjContainerHunk {
 }
 
 impl ObjContainerHunk {
-    pub fn new(
-        name_id: u32,
-        old_def_version: u32,
-        old_imp_version: u32,
-        current_version: u32,
-    ) -> Self {
+    fn new(name_id: u32, old_def_version: u32, old_imp_version: u32, current_version: u32) -> Self {
         Self {
             name_id: name_id,
             old_def_version: old_def_version,
             old_imp_version: old_imp_version,
             current_version: current_version,
         }
+    }
+
+    pub fn old_def_version(&self) -> u32 {
+        self.old_def_version
+    }
+
+    pub fn old_imp_version(&self) -> u32 {
+        self.old_imp_version
+    }
+
+    pub fn current_version(&self) -> u32 {
+        self.current_version
     }
 }
 
@@ -203,7 +254,7 @@ pub struct ObjImportHunk {
 }
 
 impl ObjImportHunk {
-    pub fn new(name_id: u32) -> Self {
+    fn new(name_id: u32) -> Self {
         Self { name_id: name_id }
     }
 }
@@ -215,11 +266,15 @@ pub struct DataPointerHunk {
 }
 
 impl DataPointerHunk {
-    pub fn new(name_id: u32, data_id: u32) -> Self {
+    fn new(name_id: u32, data_id: u32) -> Self {
         Self {
             name_id: name_id,
             data_name: data_id,
         }
+    }
+
+    pub fn data_name_id(&self) -> u32 {
+        self.data_name
     }
 }
 
@@ -230,11 +285,15 @@ pub struct XPointerHunk {
 }
 
 impl XPointerHunk {
-    pub fn new(name_id: u32, xv_id: u32) -> Self {
+    fn new(name_id: u32, xv_id: u32) -> Self {
         Self {
             name_id: name_id,
             xvector_name: xv_id,
         }
+    }
+
+    pub fn xvector_name(&self) -> u32 {
+        self.xvector_name
     }
 }
 
@@ -250,6 +309,10 @@ impl XVectorHunk {
             function_name: f_name,
         }
     }
+
+    pub fn function_name(&self) -> u32 {
+        self.function_name
+    }
 }
 
 #[derive(NameIdFromObject, Debug, Clone)]
@@ -263,6 +326,10 @@ impl ObjSourceHunk {
             name_id: name_id,
             moddate: moddate,
         }
+    }
+
+    pub fn moddate(&self) -> u32 {
+        self.moddate
     }
 }
 
@@ -288,6 +355,10 @@ impl ObjMethHunk {
             size: size,
         }
     }
+
+    pub fn size(&self) -> u32 {
+        self.size
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -301,6 +372,14 @@ impl ObjClassPair {
             base_id: base_id,
             bias: bias,
         }
+    }
+
+    pub fn base_id(&self) -> u32 {
+        self.base_id
+    }
+
+    pub fn bias(&self) -> u32 {
+        self.bias
     }
 }
 
@@ -318,6 +397,18 @@ impl ObjClassHunk {
             methods: num_methods,
             pairs: pairs,
         }
+    }
+
+    pub fn methods(&self) -> u16 {
+        self.methods
+    }
+
+    pub fn pairs(&self) -> &[ObjClassPair] {
+        &self.pairs
+    }
+
+    pub fn pairs_iter(&self) -> Iter<ObjClassPair> {
+        self.pairs.iter()
     }
 }
 
@@ -388,7 +479,7 @@ impl Default for Hunk {
 }
 
 impl Hunk {
-    pub fn new(hunk: HunkType) -> Self {
+    fn new(hunk: HunkType) -> Self {
         Self { hunk: hunk }
     }
 }

--- a/src/code_m68k.rs
+++ b/src/code_m68k.rs
@@ -733,6 +733,7 @@ impl TryFrom<u16> for HunkParseState {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct CodeHunks {
     hunks: Vec<Hunk>,
 }

--- a/src/mwob_library.rs
+++ b/src/mwob_library.rs
@@ -3,7 +3,7 @@ use std::ffi::CStr;
 use std::slice::Iter;
 
 #[repr(u32)]
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LibraryMagicWord {
     LibraryMagicWord = 0x4d574f42,
 }
@@ -15,7 +15,7 @@ impl Default for LibraryMagicWord {
 }
 
 #[repr(u32)]
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LibraryProcessor {
     Unknown = 0,
     PowerPC = 0x50504320,
@@ -39,7 +39,7 @@ impl From<u32> for LibraryProcessor {
 }
 
 #[repr(u32)]
-#[derive(Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, Copy, PartialEq)]
 pub enum LibraryFlags {
     None = 0,
 }
@@ -99,6 +99,7 @@ impl FileObject {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct MetroWerksLibrary {
     proc: LibraryProcessor,
     flags: LibraryFlags,
@@ -286,10 +287,14 @@ mod tests {
 
         let l = MetroWerksLibrary::try_from(ve.as_ref()).unwrap();
 
+        println!("{:#?}", l);
         println!("{} objects.", l.file_count());
 
         for raw_file in l.file_iter() {
             let ob = MetrowerksObject::try_from(raw_file.as_bytes()).unwrap();
+
+            println!("{:#?}", ob);
+
             assert_eq!(
                 3,
                 ob.names().len(),

--- a/src/mwob_library.rs
+++ b/src/mwob_library.rs
@@ -1,9 +1,9 @@
 use super::util;
 use std::ffi::CStr;
-use std::ffi::CString;
 use std::slice::Iter;
 
-#[derive(PartialEq)]
+#[repr(u32)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum LibraryMagicWord {
     LibraryMagicWord = 0x4d574f42,
 }
@@ -14,7 +14,8 @@ impl Default for LibraryMagicWord {
     }
 }
 
-#[derive(PartialEq)]
+#[repr(u32)]
+#[derive(Clone, Copy, PartialEq)]
 pub enum LibraryProcessor {
     Unknown = 0,
     PowerPC = 0x50504320,
@@ -37,193 +38,42 @@ impl From<u32> for LibraryProcessor {
     }
 }
 
-#[derive(PartialEq)]
-pub enum LibraryHeaderFlags {
+#[repr(u32)]
+#[derive(Clone, Copy, PartialEq)]
+pub enum LibraryFlags {
     None = 0,
 }
-
-pub struct LibraryHeader {
-    proc: LibraryProcessor,
-    flags: LibraryHeaderFlags,
-    version: u32,
-    code_size: u32,
-    data_size: u32,
-    num_object_files: u32,
-}
-
-impl Default for LibraryHeader {
-    fn default() -> Self {
-        Self {
-            proc: LibraryProcessor::Unknown,
-            flags: LibraryHeaderFlags::None,
-            version: 0,
-            code_size: 0,
-            data_size: 0,
-            num_object_files: 0,
-        }
-    }
-}
-
-impl LibraryHeader {
-    pub fn proc(self, proc: LibraryProcessor) -> Self {
-        Self {
-            proc: proc,
-            flags: self.flags,
-            version: self.version,
-            code_size: self.code_size,
-            data_size: self.data_size,
-            num_object_files: self.num_object_files,
-        }
-    }
-
-    pub fn flags(self, flags: LibraryHeaderFlags) -> Self {
-        Self {
-            proc: self.proc,
-            flags: flags,
-            version: self.version,
-            code_size: self.code_size,
-            data_size: self.data_size,
-            num_object_files: self.num_object_files,
-        }
-    }
-
-    pub fn version(self, version: u32) -> Self {
-        Self {
-            proc: self.proc,
-            flags: self.flags,
-            version: version,
-            code_size: self.code_size,
-            data_size: self.data_size,
-            num_object_files: self.num_object_files,
-        }
-    }
-
-    pub fn code_size(self, code_size: u32) -> Self {
-        Self {
-            proc: self.proc,
-            flags: self.flags,
-            version: self.version,
-            code_size: code_size,
-            data_size: self.data_size,
-            num_object_files: self.num_object_files,
-        }
-    }
-
-    pub fn data_size(self, data_size: u32) -> Self {
-        Self {
-            proc: self.proc,
-            flags: self.flags,
-            version: self.version,
-            code_size: self.code_size,
-            data_size: data_size,
-            num_object_files: self.num_object_files,
-        }
-    }
-
-    pub fn num_object_files(self, num_object_files: u32) -> Self {
-        Self {
-            proc: self.proc,
-            flags: self.flags,
-            version: self.version,
-            code_size: self.code_size,
-            data_size: self.data_size,
-            num_object_files: num_object_files,
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub struct FileHeader {
-    moddate: u32,
-    filename: CString,
-    fullpathname: CString,
-    object_start: u32,
-    object_size: u32,
-}
-
-impl FileHeader {
-    pub fn new() -> Self {
-        Self {
-            moddate: 0,
-            filename: CString::new("").unwrap(),
-            fullpathname: CString::new("").unwrap(),
-            object_start: 0,
-            object_size: 0,
-        }
-    }
-    pub fn mod_date(self, moddate: u32) -> Self {
-        Self {
-            moddate: moddate,
-            filename: self.filename,
-            fullpathname: self.fullpathname,
-            object_start: self.object_start,
-            object_size: self.object_size,
-        }
-    }
-
-    pub fn filename(self, filename: CString) -> Self {
-        Self {
-            moddate: self.moddate,
-            filename: filename.clone(),
-            fullpathname: self.fullpathname,
-            object_start: self.object_start,
-            object_size: self.object_size,
-        }
-    }
-
-    pub fn fullpathname(self, fullpathname: CString) -> Self {
-        Self {
-            moddate: self.moddate,
-            filename: self.filename,
-            fullpathname: fullpathname.clone(),
-            object_start: self.object_start,
-            object_size: self.object_size,
-        }
-    }
-
-    pub fn object_start(self, object_start: u32) -> Self {
-        Self {
-            moddate: self.moddate,
-            filename: self.filename,
-            fullpathname: self.fullpathname,
-            object_start: object_start,
-            object_size: self.object_size,
-        }
-    }
-
-    pub fn object_size(self, object_size: u32) -> Self {
-        Self {
-            moddate: self.moddate,
-            filename: self.filename,
-            fullpathname: self.fullpathname,
-            object_start: self.object_start,
-            object_size: object_size,
-        }
-    }
-
-    pub fn start(&self) -> usize {
-        self.object_start as usize
-    }
-
-    pub fn end(&self) -> usize {
-        (self.object_start + self.object_size) as usize
-    }
-
-    pub fn length(&self) -> usize {
-        self.object_size as usize
+impl LibraryFlags {
+    fn default() -> LibraryFlags {
+        LibraryFlags::None
     }
 }
 
 #[derive(Debug, Clone)]
 pub struct FileObject {
-    header: FileHeader,
+    moddate: u32,
+    file_name: String,
+    full_path: String,
     data: Vec<u8>,
 }
 
-impl FileObject {
-    pub fn new(header: FileHeader, data: &[u8]) -> Self {
+impl Default for FileObject {
+    fn default() -> Self {
         Self {
-            header: header,
+            moddate: 0,
+            file_name: String::new(),
+            full_path: String::new(),
+            data: vec![],
+        }
+    }
+}
+
+impl FileObject {
+    fn new(moddate: u32, file_name: String, full_path: String, data: &[u8]) -> Self {
+        Self {
+            moddate: moddate,
+            file_name: file_name,
+            full_path: full_path,
             data: data.to_vec(),
         }
     }
@@ -232,22 +82,58 @@ impl FileObject {
         self.data.as_slice()
     }
 
-    pub fn filename(&self) -> &CStr {
-        self.header.filename.as_c_str()
+    pub fn length(&self) -> usize {
+        self.data.len()
+    }
+
+    pub fn filename(&self) -> &str {
+        self.file_name.as_str()
+    }
+
+    pub fn fullpath(&self) -> &str {
+        self.full_path.as_str()
+    }
+
+    pub fn moddate(&self) -> u32 {
+        self.moddate
     }
 }
 
 pub struct MetroWerksLibrary {
-    header: LibraryHeader,
+    proc: LibraryProcessor,
+    flags: LibraryFlags,
+    version: u32,
     files: Vec<FileObject>,
 }
 
 impl MetroWerksLibrary {
-    pub fn new(header: LibraryHeader, files: Vec<FileObject>) -> Self {
+    fn new(
+        proc: LibraryProcessor,
+        flags: LibraryFlags,
+        version: u32,
+        files: Vec<FileObject>,
+    ) -> Self {
         Self {
-            header: header,
+            proc: proc,
+            flags: flags,
+            version: version,
             files: files,
         }
+    }
+
+    #[inline(always)]
+    pub fn proc(&self) -> LibraryProcessor {
+        self.proc
+    }
+
+    #[inline(always)]
+    pub fn flags(&self) -> LibraryFlags {
+        self.flags
+    }
+
+    #[inline(always)]
+    pub fn version(&self) -> u32 {
+        self.version
     }
 
     #[inline(always)]
@@ -259,183 +145,108 @@ impl MetroWerksLibrary {
     pub fn file_count(&self) -> usize {
         self.files.len()
     }
-
-    pub fn header(&self) -> &LibraryHeader {
-        &self.header
-    }
 }
 
 #[derive(PartialEq)]
 enum LibraryParseState {
-    LibraryHeaderStart,
-    LibraryHeaderMagicWord,
-    LibraryHeaderProc,
-    LibraryHeaderFlags,
-    LibraryHeaderVersion,
-    LibraryHeaderCodeSize,
-    LibraryHeaderDataSize,
-    LibraryHeaderNumObjFiles,
+    Start,
+    ParseLibraryHeader,
 
     FileStart,
-    FileHeaderModDate,
-    FileHeaderFileName,
-    FileHeaderFullPathName,
-    FileHeaderObjStart,
-    FileHeaderObjSize,
-    FileDataBytes,
-    FileCommit,
+    CommitFile,
 
     End,
 }
 
 impl Default for LibraryParseState {
     fn default() -> Self {
-        LibraryParseState::LibraryHeaderStart
+        LibraryParseState::Start
     }
 }
 
 pub fn parse_library(value: &[u8]) -> Result<MetroWerksLibrary, String> {
-    let mut header: LibraryHeader = LibraryHeader::default();
+    let mut data: &[u8] = value;
     let mut files: Vec<FileObject> = Vec::new();
-    let mut curr_file_header: FileHeader = FileHeader::new();
-    let mut curr_file_data = <&[u8]>::default();
+    let mut current_file = FileObject::default();
     let mut remaining_files = 0;
 
-    let mut offset: usize = 28; // We don't use this var until later, so this is okay.
+    let mut proc = LibraryProcessor::default();
+    let mut flags = LibraryFlags::default();
+    let mut version: u32 = 0;
 
     let mut state: LibraryParseState = LibraryParseState::default();
     while state != LibraryParseState::End {
         state = match state {
-            LibraryParseState::LibraryHeaderStart => LibraryParseState::LibraryHeaderMagicWord,
-            LibraryParseState::LibraryHeaderMagicWord => {
-                let x = util::convert_be_u32(&value[0..4].try_into().unwrap());
+            LibraryParseState::Start => LibraryParseState::ParseLibraryHeader,
+            LibraryParseState::ParseLibraryHeader => {
+                let magic = util::convert_be_u32(&data[0..4].try_into().unwrap());
 
-                if x != LibraryMagicWord::LibraryMagicWord as u32 {
+                if magic != LibraryMagicWord::LibraryMagicWord as u32 {
                     return Err(format!(
                         "Bad Magic Word: Expected: {}, got: {}",
                         LibraryMagicWord::LibraryMagicWord as u32,
-                        x
+                        magic
                     ));
                 }
 
-                LibraryParseState::LibraryHeaderProc
+                let proc_u32 = util::convert_be_u32(&data[4..8].try_into().unwrap());
+                proc = LibraryProcessor::from(proc_u32);
+
+                let flags_u32 = util::convert_be_u32(&data[8..12].try_into().unwrap());
+                if flags_u32 != 0 {
+                    return Err(format!("Bad flags for header, got: {}", flags_u32));
+                }
+                flags = LibraryFlags::None;
+
+                version = util::convert_be_u32(&data[12..16].try_into().unwrap());
+
+                let num_objects = util::convert_be_u32(&data[24..28].try_into().unwrap());
+
+                if num_objects != 0 {
+                    data = &data[28..];
+                    remaining_files = num_objects;
+                    LibraryParseState::FileStart
+                } else {
+                    LibraryParseState::End
+                }
             }
-            LibraryParseState::LibraryHeaderProc => {
-                let x = util::convert_be_u32(&value[4..8].try_into().unwrap());
 
-                header = header.proc(LibraryProcessor::from(x));
-
-                LibraryParseState::LibraryHeaderFlags
-            }
-            LibraryParseState::LibraryHeaderFlags => {
-                // This field is not used per the CW11 API documentation (8..12)
-                header = header.flags(LibraryHeaderFlags::None);
-
-                LibraryParseState::LibraryHeaderVersion
-            }
-            LibraryParseState::LibraryHeaderVersion => {
-                let x = util::convert_be_u32(&value[12..16].try_into().unwrap());
-
-                header = header.version(x);
-
-                LibraryParseState::LibraryHeaderCodeSize
-            }
-            LibraryParseState::LibraryHeaderCodeSize => {
-                let x = util::convert_be_u32(&value[16..20].try_into().unwrap());
-
-                header = header.code_size(x);
-
-                LibraryParseState::LibraryHeaderDataSize
-            }
-            LibraryParseState::LibraryHeaderDataSize => {
-                let x = util::convert_be_u32(&value[20..24].try_into().unwrap());
-
-                header = header.data_size(x);
-
-                LibraryParseState::LibraryHeaderNumObjFiles
-            }
-            LibraryParseState::LibraryHeaderNumObjFiles => {
-                let x = util::convert_be_u32(&value[24..28].try_into().unwrap());
-
-                header = header.num_object_files(x);
-                remaining_files = x;
-
-                // Next stage starts processing the file objects
-                LibraryParseState::FileStart
-            }
             LibraryParseState::FileStart => {
-                curr_file_header = FileHeader::new();
-                curr_file_data = <&[u8]>::default();
+                let file_moddate = util::convert_be_u32(&data[0..4].try_into().unwrap());
+                let file_name_loc = util::convert_be_u32(&data[4..8].try_into().unwrap()) as usize;
+                let full_path_loc = util::convert_be_u32(&data[8..12].try_into().unwrap()) as usize;
+                let data_start: usize =
+                    util::convert_be_u32(&data[12..16].try_into().unwrap()) as usize;
+                let data_size: usize =
+                    util::convert_be_u32(&data[16..20].try_into().unwrap()) as usize;
 
-                LibraryParseState::FileHeaderModDate
-            }
-            LibraryParseState::FileHeaderModDate => {
-                let x = util::convert_be_u32(&value[offset..(offset + 4)].try_into().unwrap());
-
-                curr_file_header = curr_file_header.mod_date(x);
-                offset += 4;
-
-                LibraryParseState::FileHeaderFileName
-            }
-            LibraryParseState::FileHeaderFileName => {
-                let x = util::convert_be_u32(&value[offset..(offset + 4)].try_into().unwrap());
-
-                let file_name = CStr::from_bytes_until_nul(&value[x as usize..])
+                // The file_name, full_path, and bytes are relative to the LIBRARY Header not the FILE Header
+                let file_name = CStr::from_bytes_until_nul(&value[file_name_loc..])
+                    .unwrap()
+                    .to_str()
                     .unwrap()
                     .to_owned();
 
-                offset += 4;
-                curr_file_header = curr_file_header.filename(file_name);
-
-                LibraryParseState::FileHeaderFullPathName
-            }
-            LibraryParseState::FileHeaderFullPathName => {
-                let x = util::convert_be_u32(&value[offset..(offset + 4)].try_into().unwrap());
-
-                let full_file_path = if x == 0 {
-                    CString::new("").unwrap()
+                let full_path: String = if full_path_loc == 0 {
+                    String::new()
                 } else {
-                    CStr::from_bytes_until_nul(&value[x as usize..])
+                    CStr::from_bytes_until_nul(&value[full_path_loc as usize..])
+                        .unwrap()
+                        .to_str()
                         .unwrap()
                         .to_owned()
                 };
 
-                offset += 4;
-                curr_file_header = curr_file_header.fullpathname(full_file_path);
+                // The bytes are relative to the LIBRARY Header not the FILE Header
+                let bytes = &value[data_start..(data_start + data_size)];
+                data = &data[20..];
 
-                LibraryParseState::FileHeaderObjStart
+                current_file = FileObject::new(file_moddate, file_name, full_path, bytes);
+
+                LibraryParseState::CommitFile
             }
-            LibraryParseState::FileHeaderObjStart => {
-                let x = util::convert_be_u32(&value[offset..(offset + 4)].try_into().unwrap());
-
-                curr_file_header = curr_file_header.object_start(x);
-                offset += 4;
-
-                LibraryParseState::FileHeaderObjSize
-            }
-            LibraryParseState::FileHeaderObjSize => {
-                let x = util::convert_be_u32(&value[offset..(offset + 4)].try_into().unwrap());
-
-                curr_file_header = curr_file_header.object_size(x);
-                offset += 4;
-
-                LibraryParseState::FileDataBytes
-            }
-            LibraryParseState::FileDataBytes => {
-                let start: usize = curr_file_header.start();
-                //let size: usize = curr_file_header.object_size;
-                let end = curr_file_header.end();
-
-                let bytes = &value[start..end];
-
-                curr_file_data = bytes;
-                offset += curr_file_header.length();
-
-                LibraryParseState::FileCommit
-            }
-            LibraryParseState::FileCommit => {
-                let file = FileObject::new(curr_file_header.clone(), curr_file_data);
-                files.push(file);
+            LibraryParseState::CommitFile => {
+                files.push(current_file.clone());
                 remaining_files -= 1;
 
                 if remaining_files == 0 {
@@ -448,7 +259,7 @@ pub fn parse_library(value: &[u8]) -> Result<MetroWerksLibrary, String> {
         }
     }
 
-    Ok(MetroWerksLibrary::new(header, files))
+    Ok(MetroWerksLibrary::new(proc, flags, version, files))
 }
 
 impl TryFrom<&[u8]> for MetroWerksLibrary {
@@ -461,7 +272,7 @@ impl TryFrom<&[u8]> for MetroWerksLibrary {
 
 #[cfg(test)]
 mod tests {
-    use crate::objects_m68k::Object;
+    use crate::objects_m68k::MetrowerksObject;
 
     use super::*;
     use std::fs::File;
@@ -478,7 +289,7 @@ mod tests {
         println!("{} objects.", l.file_count());
 
         for raw_file in l.file_iter() {
-            let ob = Object::try_from(raw_file.as_bytes()).unwrap();
+            let ob = MetrowerksObject::try_from(raw_file.as_bytes()).unwrap();
             assert_eq!(
                 3,
                 ob.names().len(),

--- a/src/objects_m68k.rs
+++ b/src/objects_m68k.rs
@@ -32,6 +32,7 @@ bitflags! {
    }
 }
 
+#[derive(Debug, Clone)]
 pub struct NameEntry {
     id: u32,
     name: CString,
@@ -60,6 +61,7 @@ impl NameEntry {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct ObjectHeader {
     version: u16, /* always OBJ_VERSION */
     flags: ObjectFlags,
@@ -588,6 +590,7 @@ impl ObjectHeader {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct MetrowerksObject {
     header: ObjectHeader,
     names: Vec<NameEntry>,

--- a/src/objects_m68k.rs
+++ b/src/objects_m68k.rs
@@ -47,7 +47,7 @@ impl Default for NameEntry {
 }
 
 impl NameEntry {
-    pub fn new(id: u32, name: CString) -> Self {
+    fn new(id: u32, name: CString) -> Self {
         Self { id: id, name: name }
     }
 
@@ -588,14 +588,14 @@ impl ObjectHeader {
     }
 }
 
-pub struct Object {
+pub struct MetrowerksObject {
     header: ObjectHeader,
     names: Vec<NameEntry>,
     symtab: SymbolTable,
     hunks: CodeHunks,
 }
 
-impl Default for Object {
+impl Default for MetrowerksObject {
     fn default() -> Self {
         Self {
             header: ObjectHeader::default(),
@@ -606,7 +606,7 @@ impl Default for Object {
     }
 }
 
-impl Object {
+impl MetrowerksObject {
     fn new(
         header: ObjectHeader,
         names: Vec<NameEntry>,
@@ -621,7 +621,7 @@ impl Object {
         }
     }
 
-    pub fn names(&self) -> &Vec<NameEntry> {
+    pub fn names(&self) -> &[NameEntry] {
         &self.names
     }
 
@@ -687,7 +687,7 @@ impl Default for ObjectParseState {
     }
 }
 
-fn parse_object(value: &[u8]) -> Result<Object, String> {
+fn parse_object(value: &[u8]) -> Result<MetrowerksObject, String> {
     let mut header: ObjectHeader = ObjectHeader::default();
 
     let mut remaining_names: usize = 0;
@@ -938,10 +938,15 @@ fn parse_object(value: &[u8]) -> Result<Object, String> {
         }
     }
 
-    Ok(Object::new(header, name_table, symbol_table, code_objects))
+    Ok(MetrowerksObject::new(
+        header,
+        name_table,
+        symbol_table,
+        code_objects,
+    ))
 }
 
-impl TryFrom<&[u8]> for Object {
+impl TryFrom<&[u8]> for MetrowerksObject {
     type Error = String;
 
     fn try_from(value: &[u8]) -> Result<Self, Self::Error> {

--- a/src/proc_macros/mod.rs
+++ b/src/proc_macros/mod.rs
@@ -22,7 +22,8 @@ fn impl_name_macro(ast: &syn::DeriveInput) -> TokenStream {
     let name = &ast.ident;
     let gen = quote! {
         impl NameIdFromObject for #name {
-            fn name(&self, obj: crate::objects_m68k::Object) -> String {
+
+            fn name(&self, obj: crate::objects_m68k::MetrowerksObject) -> String {
                 obj.names()[(self.name_id + 1) as usize]
                     .name()
                     .clone()

--- a/src/symtable_m68k.rs
+++ b/src/symtable_m68k.rs
@@ -114,14 +114,14 @@ impl Default for SymbolTable {
 }
 
 impl SymbolTable {
-    pub fn new(routines: Vec<Routine>, type_table: TypeTable) -> Self {
+    fn new(routines: Vec<Routine>, type_table: TypeTable) -> Self {
         Self {
             routines: routines,
             types: type_table,
         }
     }
 
-    pub fn routines(&self) -> &Vec<Routine> {
+    pub fn routines(&self) -> &[Routine] {
         &self.routines
     }
 
@@ -178,7 +178,8 @@ impl From<&[u8]> for StatementLocation {
     }
 }
 
-#[derive(Debug, Clone)]
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum StorageKind {
     Local = 0,
     Value,
@@ -200,7 +201,8 @@ impl TryFrom<u8> for StorageKind {
     }
 }
 
-#[derive(Debug, Clone)]
+#[repr(u8)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
 pub enum StorageClass {
     Register = 0,
     A5,
@@ -231,7 +233,7 @@ pub struct LocalVar {
     var_type: DataType,
     kind: StorageKind,
     sclass: StorageClass,
-    wher: u32,
+    wher: u32, // TODO: Integrate this into the sclass
 }
 
 impl From<&[u8]> for LocalVar {
@@ -249,6 +251,24 @@ impl From<&[u8]> for LocalVar {
             sclass: sclass,
             wher: wher,
         }
+    }
+}
+
+impl LocalVar {
+    pub fn var_type(&self) -> &DataType {
+        &self.var_type
+    }
+
+    pub fn kind(&self) -> StorageKind {
+        self.kind
+    }
+
+    pub fn storage_class(&self) -> StorageClass {
+        self.sclass
+    }
+
+    pub fn wher(&self) -> u32 {
+        self.wher
     }
 }
 

--- a/src/symtable_m68k.rs
+++ b/src/symtable_m68k.rs
@@ -99,6 +99,7 @@ impl Default for ParseState {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct SymbolTable {
     routines: Vec<Routine>,
     types: TypeTable,

--- a/src/types_m68k.rs
+++ b/src/types_m68k.rs
@@ -531,6 +531,7 @@ impl Default for TypeParseState {
     }
 }
 
+#[derive(Debug, Clone)]
 pub struct TypeTable {
     table: Vec<TypeDefinition>,
 }

--- a/src/types_m68k.rs
+++ b/src/types_m68k.rs
@@ -1,4 +1,4 @@
-use std::slice::Iter;
+use std::{ops::Range, slice::Iter};
 
 use super::util::{convert_be_u16, convert_be_u32, NameIdFromObject};
 
@@ -143,6 +143,14 @@ impl Pointer {
             typ: typ,
         }
     }
+
+    pub fn number(&self) -> u16 {
+        self.number
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        &self.typ
+    }
 }
 #[derive(Debug, Clone)]
 pub struct Array {
@@ -158,6 +166,18 @@ impl Array {
             esize: esize,
             typ: typ,
         }
+    }
+
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+
+    pub fn esize(&self) -> u32 {
+        self.esize
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        &self.typ
     }
 }
 
@@ -175,6 +195,14 @@ impl StructMember {
             offset: offset,
         }
     }
+
+    pub fn data_type(&self) -> &DataType {
+        &self.typ
+    }
+
+    pub fn offset(&self) -> u32 {
+        self.offset
+    }
 }
 
 #[derive(NameIdFromObject, Debug, Clone)]
@@ -191,6 +219,18 @@ impl Struct {
             members: members,
         }
     }
+
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+
+    pub fn members(&self) -> &[StructMember] {
+        &self.members
+    }
+
+    pub fn member_iter(&self) -> Iter<StructMember> {
+        self.members.iter()
+    }
 }
 
 #[derive(NameIdFromObject, Debug, Clone)]
@@ -205,21 +245,37 @@ impl EnumMember {
             value: value,
         }
     }
+
+    pub fn value(&self) -> u32 {
+        self.value
+    }
 }
 
 #[derive(NameIdFromObject, Debug, Clone)]
 pub struct Enum {
     name_id: u32,
-    typ: BasicDataType,
+    typ: DataType,
     members: Vec<EnumMember>,
 }
 impl Enum {
     fn new(name: u32, typ: BasicDataType, members: Vec<EnumMember>) -> Enum {
         Self {
             name_id: name,
-            typ: typ,
+            typ: DataType::BasicDataType(typ),
             members: members,
         }
+    }
+
+    pub fn members(&self) -> &[EnumMember] {
+        &self.members
+    }
+
+    pub fn member_iter(&self) -> Iter<EnumMember> {
+        self.members.iter()
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        &self.typ
     }
 }
 
@@ -241,6 +297,22 @@ impl PascalArray {
             name_id: name,
         }
     }
+
+    pub fn is_packed(&self) -> bool {
+        self.packed
+    }
+
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+
+    pub fn iid(&self) -> u32 {
+        self.iid
+    }
+
+    pub fn eid(&self) -> &DataType {
+        &self.eid
+    }
 }
 
 #[derive(NameIdFromObject, Debug, Clone)]
@@ -261,6 +333,28 @@ impl PascalRange {
             upper: hbound,
         }
     }
+
+    pub fn lower(&self) -> u32 {
+        self.lower
+    }
+
+    pub fn upper(&self) -> u32 {
+        self.upper
+    }
+
+    pub fn size(&self) -> u32 {
+        self.size
+    }
+
+    pub fn data_type(&self) -> &DataType {
+        &self.typ
+    }
+}
+
+impl Into<Range<u32>> for PascalRange {
+    fn into(self) -> Range<u32> {
+        self.lower..self.upper
+    }
 }
 
 #[derive(NameIdFromObject, Debug, Clone)]
@@ -277,6 +371,14 @@ impl PascalSet {
             size: size,
         }
     }
+
+    pub fn base(&self) -> &DataType {
+        &self.base
+    }
+
+    pub fn size(&self) -> usize {
+        self.size as usize
+    }
 }
 
 #[derive(NameIdFromObject, Debug, Clone)]
@@ -291,6 +393,14 @@ impl PascalEnum {
             members: members,
         }
     }
+
+    pub fn members_iter(&self) -> Iter<u32> {
+        self.members.iter()
+    }
+
+    pub fn members(&self) -> &[u32] {
+        &self.members
+    }
 }
 
 #[derive(NameIdFromObject, Debug, Clone)]
@@ -304,6 +414,10 @@ impl PascalString {
             name_id: name,
             size: size,
         }
+    }
+
+    pub fn size(&self) -> u32 {
+        self.size
     }
 }
 
@@ -428,7 +542,7 @@ impl Default for TypeTable {
 }
 
 impl TypeTable {
-    pub fn types(&self) -> &Vec<TypeDefinition> {
+    pub fn types(&self) -> &[TypeDefinition] {
         &self.table
     }
 
@@ -437,13 +551,13 @@ impl TypeTable {
     }
 }
 
-pub struct TypeTableInput<'a> {
+pub(crate) struct TypeTableInput<'a> {
     p: &'a [u8],
     num: u32,
 }
 
 impl<'a> TypeTableInput<'a> {
-    pub fn new(p: &'a [u8], num_members: u32) -> Self {
+    pub(crate) fn new(p: &'a [u8], num_members: u32) -> Self {
         Self {
             p: p,
             num: num_members,

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,9 +1,9 @@
 use std::collections::VecDeque;
 
-use crate::objects_m68k::Object;
+use crate::objects_m68k::MetrowerksObject;
 
 pub trait NameIdFromObject: Sized {
-    fn name(&self, obj: Object) -> String;
+    fn name(&self, obj: MetrowerksObject) -> String;
 }
 
 const NAMEHASH: u16 = 1024;
@@ -35,13 +35,4 @@ pub fn convert_be_u16(data: &[u8; 2]) -> u16 {
 pub fn convert_be_u32(data: &[u8; 4]) -> u32 {
     let res: u32 = unsafe { std::mem::transmute(*data) };
     u32::from_be(res)
-}
-
-#[allow(unused_imports)]
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn hashcheck_1() {}
 }


### PR DESCRIPTION
Small refractors to parsing

* Cleans up some older parse code that wasn't compacted.
* Adds getters to things..
* Just putting `#[derive(Debug, Clone)]` on everything...
* Remove `pub` on some new functions not used outside of their mod.